### PR TITLE
feat: add webphone extension availability support

### DIFF
--- a/src/Cloudpbx/Sdk/Client.php
+++ b/src/Cloudpbx/Sdk/Client.php
@@ -109,4 +109,9 @@ interface Client
      * @return AclIpv4
      */
     public function getAclIpv4s();
+
+    /**
+     * @return Webphone
+     */
+    public function getWebphone();
 }

--- a/src/Cloudpbx/Sdk/Implementation/Client.php
+++ b/src/Cloudpbx/Sdk/Implementation/Client.php
@@ -33,6 +33,7 @@ use Cloudpbx\Sdk\AclIpv4;
 use Cloudpbx\Sdk\Customer;
 use Cloudpbx\Sdk\FirewallIpSet;
 use Cloudpbx\Sdk\Provisioning;
+use Cloudpbx\Sdk\Webphone;
 use Cloudpbx\Sdk\Model\Relation;
 
 /**
@@ -47,6 +48,7 @@ use Cloudpbx\Sdk\Model\Relation;
  * @property Voicemail $voicemails
  * @property DialoutGroup $dialoutGroups
  * @property Provisioning $provisioning
+ * @property Webphone $webphone
  */
 final class Client implements \Cloudpbx\Sdk\Client
 {
@@ -226,6 +228,14 @@ final class Client implements \Cloudpbx\Sdk\Client
     public function getProvisioning()
     {
         return Provisioning::fromTransport($this->protocol);
+    }
+
+    /**
+     * @return Webphone
+     */
+    public function getWebphone()
+    {
+        return Webphone::fromTransport($this->protocol);
     }
 
     /**

--- a/src/Cloudpbx/Sdk/Model/Webphone/ExtensionAvailability.php
+++ b/src/Cloudpbx/Sdk/Model/Webphone/ExtensionAvailability.php
@@ -1,0 +1,44 @@
+<?php
+
+// This file is part of cloudpbx-php-sdk.  The COPYRIGHT file at the top level of
+// this repository contains the full copyright notices and license terms.
+//
+// @author (2026) Agustin Serra <agustin@picallex.com>
+
+declare(strict_types=1);
+
+namespace Cloudpbx\Sdk\Model\Webphone;
+
+final class ExtensionAvailability extends \Cloudpbx\Sdk\Model
+{
+    protected $_primary_key = null;
+
+    /**
+     * @var string
+     */
+    public $domain;
+
+    /**
+     * @var string
+     */
+    public $extension;
+
+    /**
+     * @var string
+     */
+    public $fqdn;
+
+    /**
+     * @var bool
+     */
+    public $registered;
+
+    /**
+     * @var bool
+     */
+    public $transferable;
+
+    public function __construct()
+    {
+    }
+}

--- a/src/Cloudpbx/Sdk/Model/Webphone/ExtensionAvailabilityList.php
+++ b/src/Cloudpbx/Sdk/Model/Webphone/ExtensionAvailabilityList.php
@@ -1,0 +1,40 @@
+<?php
+
+// This file is part of cloudpbx-php-sdk.  The COPYRIGHT file at the top level of
+// this repository contains the full copyright notices and license terms.
+//
+// @author (2026) Agustin Serra <agustin@picallex.com>
+
+declare(strict_types=1);
+
+namespace Cloudpbx\Sdk\Model\Webphone;
+
+final class ExtensionAvailabilityList
+{
+    /**
+     * @var array<ExtensionAvailability>
+     */
+    public $data;
+
+    /**
+     * @var array<string, int>
+     */
+    public $pagination;
+
+    /**
+     * @var array<string, int>
+     */
+    public $summary;
+
+    /**
+     * @param array<ExtensionAvailability> $data
+     * @param array<string, int> $pagination
+     * @param array<string, int> $summary
+     */
+    public function __construct(array $data, array $pagination, array $summary)
+    {
+        $this->data = $data;
+        $this->pagination = $pagination;
+        $this->summary = $summary;
+    }
+}

--- a/src/Cloudpbx/Sdk/Webphone.php
+++ b/src/Cloudpbx/Sdk/Webphone.php
@@ -1,0 +1,109 @@
+<?php
+
+// This file is part of cloudpbx-php-sdk.  The COPYRIGHT file at the top level of
+// this repository contains the full copyright notices and license terms.
+//
+// @author (2026) Agustin Serra <agustin@picallex.com>
+
+declare(strict_types=1);
+
+namespace Cloudpbx\Sdk;
+
+use Cloudpbx\Util\Argument;
+
+final class Webphone extends Api
+{
+    /**
+     * Get availability for a single extension.
+     *
+     * GET /api/v1/management/webphone/extensions/{extension}/availability?domain={domain}
+     *
+     * @param string $domain
+     * @param string $extension
+     *
+     * @return Model\Webphone\ExtensionAvailability
+     */
+    public function getExtensionAvailability(string $domain, string $extension)
+    {
+        Argument::isString($domain);
+        Argument::isString($extension);
+
+        $qs = http_build_query(['domain' => $domain]);
+        $query = $this->protocol->prepareQuery(
+            '/api/v1/management/webphone/extensions/{extension}/availability?' . $qs,
+            ['{extension}' => $extension]
+        );
+
+        $record = $this->protocol->one($query);
+
+        return Model\Webphone\ExtensionAvailability::fromArray($record);
+    }
+
+    /**
+     * List availability for extensions in a domain.
+     *
+     * GET /api/v1/management/webphone/extensions/availability?domain={domain}&q={q}&limit={limit}&offset={offset}&transferable={true|false}
+     *
+     * Required params:
+     *   - domain (string)
+     *
+     * Optional params:
+     *   - q (string)
+     *   - limit (int)
+     *   - offset (int)
+     *   - transferable (bool)
+     *
+     * @param array<string, mixed> $params
+     *
+     * @return Model\Webphone\ExtensionAvailabilityList
+     */
+    public function listExtensionAvailability(array $params)
+    {
+        Argument::keyExists($params, 'domain');
+        Argument::isString($params['domain']);
+
+        $query_params = ['domain' => $params['domain']];
+
+        if (isset($params['q'])) {
+            Argument::isString($params['q']);
+            $query_params['q'] = $params['q'];
+        }
+
+        if (isset($params['limit'])) {
+            Argument::isInteger($params['limit']);
+            $query_params['limit'] = $params['limit'];
+        }
+
+        if (isset($params['offset'])) {
+            Argument::isInteger($params['offset']);
+            $query_params['offset'] = $params['offset'];
+        }
+
+        if (array_key_exists('transferable', $params)) {
+            if (!is_bool($params['transferable'])) {
+                throw new \InvalidArgumentException('transferable must be a boolean');
+            }
+            $query_params['transferable'] = $params['transferable'] ? 'true' : 'false';
+        }
+
+        $qs = http_build_query($query_params);
+        $query = $this->protocol->prepareQuery(
+            '/api/v1/management/webphone/extensions/availability?' . $qs
+        );
+
+        $raw = $this->protocol->listRaw($query);
+
+        $items = array_map(
+            function ($item) {
+                return Model\Webphone\ExtensionAvailability::fromArray($item);
+            },
+            $raw['data'] ?? []
+        );
+
+        return new Model\Webphone\ExtensionAvailabilityList(
+            $items,
+            $raw['pagination'] ?? [],
+            $raw['summary'] ?? []
+        );
+    }
+}

--- a/tests/integration/ClientTestCase.php
+++ b/tests/integration/ClientTestCase.php
@@ -131,12 +131,7 @@ class ClientTestCase extends TestCase
 
     protected function generateRandomDomain(): string
     {
-        $topLevel = ['org', 'co', 'ar'];
-        $domain = $this->randomString(range(0, 99), 30)
-                . '.'
-                . $this->randomString($topLevel, 1);
-
-        return $domain;
+        return $this->randomString(range(0, 99), 8) . '.myflexpbx.com';
     }
 
     protected function generateUserPassword(): string

--- a/tests/integration/WebphoneTest.php
+++ b/tests/integration/WebphoneTest.php
@@ -1,0 +1,196 @@
+<?php
+
+/**
+ * Copyright 2026 Picallex Holding Group. All rights reserved.
+ *
+ * @author (2026) Agustin Serra <agustin@picallex.com>
+ */
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use Cloudpbx\Sdk\Webphone;
+use Cloudpbx\Sdk\Model\Webphone\ExtensionAvailability;
+use Cloudpbx\Sdk\Model\Webphone\ExtensionAvailabilityList;
+
+final class WebphoneTest extends TestCase
+{
+    private const DOMAIN = 'test.myflexpbx.com';
+
+    /** @var array<string,mixed> */
+    private $extensionData;
+
+    /** @var array<string,mixed> */
+    private $listResponse;
+
+    protected function setUp(): void
+    {
+        $this->extensionData = [
+            'domain'       => self::DOMAIN,
+            'extension'    => '1001',
+            'fqdn'         => '1001@test.myflexpbx.com',
+            'registered'   => true,
+            'transferable' => true,
+        ];
+
+        $this->listResponse = [
+            'data' => [
+                $this->extensionData,
+                [
+                    'domain'       => self::DOMAIN,
+                    'extension'    => '1002',
+                    'fqdn'         => '1002@test.myflexpbx.com',
+                    'registered'   => false,
+                    'transferable' => false,
+                ],
+            ],
+            'pagination' => ['limit' => 20, 'offset' => 0, 'total' => 2],
+            'summary'    => ['transferable' => 1, 'not_transferable' => 1],
+        ];
+    }
+
+    private function makeWebphone(array $stubOne, array $stubListRaw): Webphone
+    {
+        $protocol = $this->createMock(\Cloudpbx\Sdk\Protocol::class);
+
+        $protocol->method('prepareQuery')->willReturnArgument(0);
+
+        if ($stubOne) {
+            $protocol->method('one')->willReturn($stubOne);
+        }
+
+        if ($stubListRaw) {
+            $protocol->method('listRaw')->willReturn($stubListRaw);
+        }
+
+        $webphone = new Webphone();
+        $ref = new \ReflectionProperty(Webphone::class, 'protocol');
+        $ref->setAccessible(true);
+        $ref->setValue($webphone, $protocol);
+
+        return $webphone;
+    }
+
+    private function makeWebphoneForGet(): Webphone
+    {
+        return $this->makeWebphone($this->extensionData, []);
+    }
+
+    private function makeWebphoneForList(): Webphone
+    {
+        return $this->makeWebphone([], $this->listResponse);
+    }
+
+    // --- getExtensionAvailability ---
+
+    public function testGetExtensionAvailabilityReturnsModel(): void
+    {
+        $result = $this->makeWebphoneForGet()->getExtensionAvailability(self::DOMAIN, '1001');
+
+        $this->assertInstanceOf(ExtensionAvailability::class, $result);
+    }
+
+    public function testGetExtensionAvailabilityMapsFields(): void
+    {
+        $result = $this->makeWebphoneForGet()->getExtensionAvailability(self::DOMAIN, '1001');
+
+        $this->assertEquals(self::DOMAIN, $result->domain);
+        $this->assertEquals('1001', $result->extension);
+        $this->assertEquals('1001@test.myflexpbx.com', $result->fqdn);
+        $this->assertTrue($result->registered);
+        $this->assertTrue($result->transferable);
+    }
+
+    public function testGetExtensionAvailabilityHasAllAttributes(): void
+    {
+        $result = $this->makeWebphoneForGet()->getExtensionAvailability(self::DOMAIN, '1001');
+
+        $this->assertTrue($result->hasAttribute('domain'));
+        $this->assertTrue($result->hasAttribute('extension'));
+        $this->assertTrue($result->hasAttribute('fqdn'));
+        $this->assertTrue($result->hasAttribute('registered'));
+        $this->assertTrue($result->hasAttribute('transferable'));
+    }
+
+    // --- listExtensionAvailability ---
+
+    public function testListExtensionAvailabilityReturnsList(): void
+    {
+        $result = $this->makeWebphoneForList()->listExtensionAvailability(['domain' => self::DOMAIN]);
+
+        $this->assertInstanceOf(ExtensionAvailabilityList::class, $result);
+    }
+
+    public function testListExtensionAvailabilityDataIsArrayOfModels(): void
+    {
+        $result = $this->makeWebphoneForList()->listExtensionAvailability(['domain' => self::DOMAIN]);
+
+        $this->assertCount(2, $result->data);
+        $this->assertInstanceOf(ExtensionAvailability::class, $result->data[0]);
+        $this->assertInstanceOf(ExtensionAvailability::class, $result->data[1]);
+    }
+
+    public function testListExtensionAvailabilityPagination(): void
+    {
+        $result = $this->makeWebphoneForList()->listExtensionAvailability(['domain' => self::DOMAIN]);
+
+        $this->assertEquals(20, $result->pagination['limit']);
+        $this->assertEquals(0, $result->pagination['offset']);
+        $this->assertEquals(2, $result->pagination['total']);
+    }
+
+    public function testListExtensionAvailabilitySummary(): void
+    {
+        $result = $this->makeWebphoneForList()->listExtensionAvailability(['domain' => self::DOMAIN]);
+
+        $this->assertEquals(1, $result->summary['transferable']);
+        $this->assertEquals(1, $result->summary['not_transferable']);
+    }
+
+    public function testListExtensionAvailabilityMapsItemFields(): void
+    {
+        $result = $this->makeWebphoneForList()->listExtensionAvailability(['domain' => self::DOMAIN]);
+
+        $first = $result->data[0];
+        $this->assertEquals(self::DOMAIN, $first->domain);
+        $this->assertEquals('1001', $first->extension);
+        $this->assertTrue($first->registered);
+        $this->assertTrue($first->transferable);
+
+        $second = $result->data[1];
+        $this->assertEquals('1002', $second->extension);
+        $this->assertFalse($second->registered);
+        $this->assertFalse($second->transferable);
+    }
+
+    public function testListExtensionAvailabilityEmptyResponse(): void
+    {
+        $empty = [
+            'data'       => [],
+            'pagination' => ['limit' => 20, 'offset' => 0, 'total' => 0],
+            'summary'    => ['transferable' => 0, 'not_transferable' => 0],
+        ];
+
+        $result = $this->makeWebphone([], $empty)->listExtensionAvailability(['domain' => self::DOMAIN]);
+
+        $this->assertCount(0, $result->data);
+        $this->assertEquals(0, $result->pagination['total']);
+    }
+
+    public function testListExtensionAvailabilityInvalidTransferableThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->makeWebphoneForList()->listExtensionAvailability([
+            'domain'       => self::DOMAIN,
+            'transferable' => 'invalid',
+        ]);
+    }
+
+    public function testListExtensionAvailabilityMissingDomainThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->makeWebphoneForList()->listExtensionAvailability([]);
+    }
+}


### PR DESCRIPTION
- Add Webphone API class with getExtensionAvailability and listExtensionAvailability
- Add ExtensionAvailability model and ExtensionAvailabilityList container
- Expose getWebphone() on Client interface and implementation
- Fix test domain generation to use .myflexpbx.com suffix
- Add mocked unit tests and manual test script